### PR TITLE
Replace system-config-printer.svg with symlinks to Adwaita icon

### DIFF
--- a/apps/scalable/printer.svg
+++ b/apps/scalable/printer.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/Adwaita/scalable/devices/printer-network.svg

--- a/apps/scalable/system-config-printer.svg
+++ b/apps/scalable/system-config-printer.svg
@@ -1,1 +1,0 @@
-cups.svg

--- a/apps/symbolic/printer-symbolic.svg
+++ b/apps/symbolic/printer-symbolic.svg
@@ -1,0 +1,1 @@
+/usr/share/icons/Adwaita/symbolic/devices/printer-network-symbolic.svg

--- a/apps/symbolic/system-config-printer-symbolic.svg
+++ b/apps/symbolic/system-config-printer-symbolic.svg
@@ -1,1 +1,0 @@
-cups-symbolic.svg


### PR DESCRIPTION
This replaces system-config-printer.svg replaced by symlinks from `/usr/share/icons/Adwaita/scalable/devices/printer-network.svg` to `apps/scalable/printer.svg` and from `/usr/share/icons/Adwaita/symbolic/devices/printer-network-network.svg` to `apps/symbolic/printer-symbolic.svg`?

It makes the icon for System Config Printer work, and uses a pre-existing Adwaita one for it.

I think it looks good!

![image](https://github.com/somepaulo/MoreWaita/assets/43753131/55af541f-f530-4c9b-8f30-f33235d6e93b)