### PR TITLE
Fix symbolic link for sublime merge

### DIFF
--- a/apps/symbolic/com.sublimemerge.App-symbolic.svg
+++ b/apps/symbolic/com.sublimemerge.App-symbolic.svg
@@ -1,1 +1,1 @@
-sublime-meerge-symbolic.svg
+sublime-merge-symbolic.svg


### PR DESCRIPTION
openSUSE build system was complaining about a link pointing to a non-existing file, since it was pointing to sublime-meerge-symbolic.svg instead of sublime-merge-symbolic.svg:

```
[    3s] ERROR: link target doesn't exist (neither in build root nor in installed system):
[    3s]   /usr/share/icons/MoreWaita/apps/symbolic/com.sublimemerge.App-symbolic.svg -> sublime-meerge-symbolic.svg
```

Appears to be the only broken symlink when checking with `find . -xtype l`