### PR TITLE
install.sh: Fix read-only filesystem detection & use proper local system location for icon install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,18 +5,8 @@ is_user_root ()
 		[ "$(id -u)" -eq 0 ]
 }
 
-check_read_only() {
-    local dir="${1}"
-    if touch "${dir}/testfilemorewaita" 2>/dev/null; then
-        rm "${dir}/testfilemorewaita"
-	return 1
-    else
-        return 0
-    fi
-}
-
 if is_user_root; then
-    if check_read_only /usr; then
+    if [ ! -w "/usr/" ]; then
         THEMEDIR="/usr/local/share/icons/MoreWaita/"
     else
         THEMEDIR="/usr/share/icons/MoreWaita/"
@@ -31,4 +21,3 @@ cp -avu "$(pwd -P)"/!(*.build|*.sh|*.py|*.md|.git|.github|.gitignore|_dev) ${THE
 shopt -u extglob
 find ${THEMEDIR} -name '*.build' -type f -delete
 gtk-update-icon-cache -f -t ${THEMEDIR} && xdg-desktop-menu forceupdate
-

--- a/install.sh
+++ b/install.sh
@@ -5,20 +5,30 @@ is_user_root ()
 		[ "$(id -u)" -eq 0 ]
 }
 
-if is_user_root; then
-    if ! ls -ld /usr | grep -q 'w'; then
-        THEMEDIR=/var/usrlocal/share/icons/MoreWaita/
+check_read_only() {
+    local dir="${1}"
+    if touch "${dir}/testfilemorewaita" 2>/dev/null; then
+        rm "${dir}/testfilemorewaita"
+	return 1
     else
-        THEMEDIR=/usr/share/icons/MoreWaita/
+        return 0
+    fi
+}
+
+if is_user_root; then
+    if check_read_only /usr; then
+        THEMEDIR="/usr/local/share/icons/MoreWaita/"
+    else
+        THEMEDIR="/usr/share/icons/MoreWaita/"
     fi
 else
-    THEMEDIR=$HOME/.local/share/icons/MoreWaita/
+    THEMEDIR="${HOME}/.local/share/icons/MoreWaita/"
 fi
 
-mkdir -p $THEMEDIR
+mkdir -p ${THEMEDIR}
 shopt -s extglob
-cp -avu "$(pwd -P)"/!(*.build|*.sh|*.py|*.md|.git|.github|.gitignore|_dev) $THEMEDIR
+cp -avu "$(pwd -P)"/!(*.build|*.sh|*.py|*.md|.git|.github|.gitignore|_dev) ${THEMEDIR}
 shopt -u extglob
-find $THEMEDIR -name '*.build' -type f -delete
-gtk-update-icon-cache -f -t $THEMEDIR && xdg-desktop-menu forceupdate
+find ${THEMEDIR} -name '*.build' -type f -delete
+gtk-update-icon-cache -f -t ${THEMEDIR} && xdg-desktop-menu forceupdate
 


### PR DESCRIPTION
Usage of bash's built-in `-w` works (and it's simpler), while grepping `ls -ld` for `w` doesn't for detecting read-only filesystem. Tested in Fedora Atomic.

`/usr/local/` is a symlink to `/var/usrlocal/` in Fedora Atomic only, so use `/usr/local/` to be more compatible.