### PR TITLE
Added Luanti (ex-Minetest) symlinks

### DIFF
--- a/scalable/apps/luanti.svg
+++ b/scalable/apps/luanti.svg
@@ -1,0 +1,1 @@
+minetest.svg

--- a/scalable/apps/meson.build
+++ b/scalable/apps/meson.build
@@ -818,9 +818,11 @@ link_files = {
         'org.xonotic.Xonotic.svg',
     ],
     'minetest.svg': [
+        'luanti.svg',
         'lutris_minetest.svg',
         'minetest-icon.svg',
         'net.minetest.Minetest.svg',
+        'org.luanti.luanti.svg',
     ],
     'libreoffice-main.svg': [
         'libreoffice7.6-main.svg',

--- a/scalable/apps/org.luanti.luanti.svg
+++ b/scalable/apps/org.luanti.luanti.svg
@@ -1,0 +1,1 @@
+minetest.svg

--- a/symbolic/apps/luanti-symbolic.svg
+++ b/symbolic/apps/luanti-symbolic.svg
@@ -1,0 +1,1 @@
+minetest-symbolic.svg

--- a/symbolic/apps/meson.build
+++ b/symbolic/apps/meson.build
@@ -778,9 +778,11 @@ link_files = {
         'org.xonotic.Xonotic-symbolic.svg',
     ],
     'minetest-symbolic.svg': [
+        'luanti-symbolic.svg',
         'lutris_minetest-symbolic.svg',
         'minetest-icon-symbolic.svg',
         'net.minetest.Minetest-symbolic.svg',
+        'org.luanti.luanti-symbolic.svg',
     ],
     'libreoffice-main-symbolic.svg': [
         'libreoffice7.6-main-symbolic.svg',

--- a/symbolic/apps/org.luanti.luanti-symbolic.svg
+++ b/symbolic/apps/org.luanti.luanti-symbolic.svg
@@ -1,0 +1,1 @@
+minetest-symbolic.svg


### PR DESCRIPTION
Minetest has been officially renamed to Luanti and uses new package and repo IDs, so I made symlinks for it. You may always rename the original icon names and remove the `luanti` symlinks instead, since "minetest" is no longer used.