### PR TITLE
Fix and prevent broken symlinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  symlinks:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check no broken symlinks
+        run: |
+          broken_symlinks="$(find . -xtype l)"
+          echo "${broken_symlinks}"
+          [[ -z "$broken_symlinks" ]]

--- a/scalable/apps/gnome-character-map.svg
+++ b/scalable/apps/gnome-character-map.svg
@@ -1,1 +1,1 @@
-accessories-character-map.svg
+../legacy/accessories-character-map.svg

--- a/symbolic/apps/pamac-manager-symbolic.svg
+++ b/symbolic/apps/pamac-manager-symbolic.svg
@@ -1,1 +1,1 @@
-system-software-install-symbolic.svg
+../legacy/system-software-install-symbolic.svg

--- a/symbolic/apps/pamac-symbolic.svg
+++ b/symbolic/apps/pamac-symbolic.svg
@@ -1,1 +1,1 @@
-system-software-install-symbolic.svg
+../legacy/system-software-install-symbolic.svg

--- a/symbolic/apps/pamac-updater-symbolic.svg
+++ b/symbolic/apps/pamac-updater-symbolic.svg
@@ -1,1 +1,1 @@
-system-software-install-symbolic.svg
+../legacy/system-software-install-symbolic.svg


### PR DESCRIPTION
Found broken symlinks while debugging stopped version updates in nixpkgs. The relevant log is available at https://nixpkgs-update-logs.nix-community.org/morewaita-icon-theme/2025-06-04.log.

To fix this, I added a simple CI check. I then corrected the four affected symlinks based on the changes in https://github.com/somepaulo/MoreWaita/compare/v48.1...v48.2.