### PR TITLE
Generized install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 is_user_root ()
 {
 		[ "$(id -u)" -eq 0 ]
 }
 
-if is_user_root; then
-    if [ ! -w "/usr/" ]; then
-        THEMEDIR="/usr/local/share/icons/MoreWaita/"
+THEMEDIR="${THEMEDIR:-}"
+
+if [ -z "$THEMEDIR" ]; then
+    if is_user_root; then
+        if [ ! -w "/usr/" ]; then
+            THEMEDIR="/usr/local/share/icons/MoreWaita/"
+        else
+            THEMEDIR="/usr/share/icons/MoreWaita/"
+        fi
     else
-        THEMEDIR="/usr/share/icons/MoreWaita/"
+        THEMEDIR="${HOME}/.local/share/icons/MoreWaita/"
     fi
-else
-    THEMEDIR="${HOME}/.local/share/icons/MoreWaita/"
 fi
 SCRIPTDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 


### PR DESCRIPTION
This pull request generalizes `install.sh` to assist package managers like Nixpkgs.

`install.sh` uses hardcoded paths for `THEMEDIR`. Consequently, downstream nixpkgs use [custom installation scripts](https://github.com/NixOS/nixpkgs/blob/96f9a7e1ea8115904a9152843f8186cc456ede60/pkgs/by-name/mo/morewaita-icon-theme/package.nix#L27-L29).
Currently it includes unnecessary build-time artifacts due to its custom installation logic. I'm writing a nixpkgs patch to fix it.

If `install.sh` can be generalized for shebang and path handling, Nixpkgs could use the official `install.sh` directly, simplifying maintenance and keeping its packaging process up-to-date.