### PR TITLE
Add WebVtt subtitles mimetype

### DIFF
--- a/scalable/mimetypes/meson.build
+++ b/scalable/mimetypes/meson.build
@@ -163,6 +163,9 @@ link_files = {
         'text-x-c++src.svg',
         'text-x-cppsrc.svg',
     ],
+    'application-x-subrip.svg': [
+        'text-vtt.svg',
+    ],
     'text-x-markdown.svg': [
         'text-markdown.svg',
     ],

--- a/scalable/mimetypes/text-vtt.svg
+++ b/scalable/mimetypes/text-vtt.svg
@@ -1,0 +1,1 @@
+application-x-subrip.svg


### PR DESCRIPTION
Add WebVtt subtitles .vtt mimetype (text-vtt), reusing the subrip .srt (application-x-subrip) icon.