### PR TITLE
fix(meson): fixed Thunderbird flatpak ID

### DIFF
--- a/scalable/apps/meson.build
+++ b/scalable/apps/meson.build
@@ -723,7 +723,7 @@ link_files = {
         'org.mozilla.vpn.svg',
     ],
     'thunderbird.svg': [
-        'org.mozilla.Thunderbird.svg',
+        'org.mozilla.thunderbird.svg',
         'thunderbird-3.0.svg',
         'thunderbird-bin.svg',
         'thunderbird-esr.svg',

--- a/symbolic/apps/meson.build
+++ b/symbolic/apps/meson.build
@@ -691,7 +691,7 @@ link_files = {
         'org.mozilla.vpn-symbolic.svg',
     ],
     'thunderbird-symbolic.svg': [
-        'org.mozilla.Thunderbird-symbolic.svg',
+        'org.mozilla.thunderbird-symbolic.svg',
         'thunderbird-3.0-symbolic.svg',
         'thunderbird-bin-symbolic.svg',
         'thunderbird-esr-symbolic.svg',


### PR DESCRIPTION
Thunderbird recently changed its flatpak ID to all lowercase, so the installation script won't work with the capitalized flatpak alias