### PR TITLE
Add ZON (Zig Object Notation) mimetype support

### DIFF
--- a/scalable/mimetypes/text-x-zon.svg
+++ b/scalable/mimetypes/text-x-zon.svg
@@ -1,0 +1,1 @@
+text-x-zig.svg


### PR DESCRIPTION
ZON files are json-like file with Zig syntax.
I propose to use the same icon for both.
Another idea is to have a double bracket icon, like this:
<img width="400" height="400" alt="zon-logo-light" src="https://github.com/user-attachments/assets/4fec783e-2ca1-4543-b3cf-90a06980af55" />